### PR TITLE
Switch Events complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ Temporary Items
 /.idea/modules/IdeaProjects.course-project-graffiti-alley-mindless-entertainment.main.iml
 /.idea/modules/IdeaProjects.course-project-graffiti-alley-mindless-entertainment.test.iml
 /.idea/misc.xml
+/src/test/test.iml

--- a/src/main/java/switch_managers/SwitchEventMediator.java
+++ b/src/main/java/switch_managers/SwitchEventMediator.java
@@ -1,0 +1,26 @@
+package switch_managers;
+
+/**
+ * Interface for switchEventMediator.
+ * The purpose of this class is to mediate communication between the stateManagers and the shell.
+ * The shell needs to know which switchEvent has been scheduled once the manager is done.
+ * Uses the mediator design pattern.
+ */
+public interface SwitchEventMediator {
+
+
+    /**
+     * @param switchEventType Stores a switchEventType for later use
+     */
+    void store(SwitchEventType switchEventType);
+
+    /**
+     * @return the stored switchEventType. Delete once accessed.
+     */
+    SwitchEventType retrieve();
+
+    /**
+     * @return Whether there is a stored SwitchEventType
+     */
+    boolean ready();
+}

--- a/src/main/java/switch_managers/SwitchEventMediatorImpl.java
+++ b/src/main/java/switch_managers/SwitchEventMediatorImpl.java
@@ -1,0 +1,35 @@
+package switch_managers;
+
+/**
+ * Implementation of SwitchEventMediator.
+ */
+public class SwitchEventMediatorImpl implements SwitchEventMediator{
+
+    private SwitchEventType currType;
+
+    /**
+     * @param switchEventType Stores a switchEventType for later use
+     */
+    @Override
+    public void store(SwitchEventType switchEventType) {
+        currType = switchEventType;
+    }
+
+    /**
+     * @return Whether there is a stored SwitchEventType
+     */
+    @Override
+    public boolean ready() {
+        return currType != null;
+    }
+
+    /**
+     * @return the stored switchEventType. Delete once accessed.
+     */
+    @Override
+    public SwitchEventType retrieve() {
+        SwitchEventType saveType = currType;
+        currType = null;
+        return saveType;
+    }
+}

--- a/src/main/java/switch_managers/SwitchEventMediatorProxy.java
+++ b/src/main/java/switch_managers/SwitchEventMediatorProxy.java
@@ -1,0 +1,59 @@
+package switch_managers;
+
+
+/**
+ * This is a proxy for the switchEventMediator.
+ */
+public class SwitchEventMediatorProxy implements SwitchEventMediator {
+
+    private static SwitchEventMediatorProxy instance;
+
+    /**
+     * @return Get the instance of the switchEventMediatorProxy globally
+     */
+    public static SwitchEventMediator getInstance() {
+        if (instance == null) {
+            instance = new SwitchEventMediatorProxy();
+            instance.service = new SwitchEventMediatorImpl();
+        }
+        return instance;
+    }
+
+    /**
+     * Private constructor to prevent instantiating
+     */
+    private SwitchEventMediatorProxy() {}
+
+    private SwitchEventMediator service;
+
+    /**
+     * @param service the implementation to direct requests to.
+     */
+    public void setService(SwitchEventMediator service) {
+        this.service = service;
+    }
+
+    /**
+     * @param switchEventType Stores a switchEventType for later use
+     */
+    @Override
+    public void store(SwitchEventType switchEventType) {
+        service.store(switchEventType);
+    }
+
+    /**
+     * @return Whether there is a stored SwitchEventType
+     */
+    @Override
+    public boolean ready() {
+        return service.ready();
+    }
+
+    /**
+     * @return the stored switchEventType. Delete once accessed.
+     */
+    @Override
+    public SwitchEventType retrieve() {
+        return service.retrieve();
+    }
+}

--- a/src/main/java/switch_managers/handlers/PauseResumeEventHandler.java
+++ b/src/main/java/switch_managers/handlers/PauseResumeEventHandler.java
@@ -5,8 +5,15 @@ import switch_managers.SwitchEventHandler;
 import switch_managers.SwitchEventType;
 import menus.PauseMenuManager;
 
+/**
+ * Handler for PAUSE and RESUME events.
+ */
 public class PauseResumeEventHandler implements SwitchEventHandler {
 
+    /**
+     * prevManager: the manager to return to after pausing.
+     * pauseMenuManager: the manager for the pause menu.
+     */
     private StateManager prevManager;
 
     private final PauseMenuManager pauseMenuManager;

--- a/src/test/java/switch_managers/ManagerControllerImplTest.java
+++ b/src/test/java/switch_managers/ManagerControllerImplTest.java
@@ -1,0 +1,26 @@
+package switch_managers;
+
+import menus.PauseMenuChoiceStateFactory;
+import menus.PauseMenuManager;
+import menus.options.ChangeOptionsStateFactory;
+import org.junit.jupiter.api.Test;
+import switch_managers.handlers.PauseResumeEventHandler;
+
+class ManagerControllerImplTest {
+
+    @Test
+    void switchManagers() {
+        ManagerControllerImpl managerController = new ManagerControllerImpl();
+
+        assert(managerController.switchManagers(SwitchEventType.PAUSE, null) == null);
+
+        PauseMenuChoiceStateFactory pauseMenuChoiceStateFactory = new PauseMenuChoiceStateFactory();
+        ChangeOptionsStateFactory changeOptionsStateFactory = new ChangeOptionsStateFactory();
+        PauseMenuManager pauseMenuManager = new PauseMenuManager(pauseMenuChoiceStateFactory, changeOptionsStateFactory);
+
+        PauseResumeEventHandler pauseResumeEventHandler = new PauseResumeEventHandler(pauseMenuManager);
+        managerController.addSwitchEventHandler(pauseResumeEventHandler);
+
+        assert(managerController.switchManagers(SwitchEventType.PAUSE, null) != null);
+    }
+}

--- a/src/test/java/switch_managers/SwitchEventMediatorImplTest.java
+++ b/src/test/java/switch_managers/SwitchEventMediatorImplTest.java
@@ -1,0 +1,16 @@
+package switch_managers;
+
+import org.junit.jupiter.api.Test;
+
+public class SwitchEventMediatorImplTest {
+
+    @Test
+    void testMessage() {
+        SwitchEventMediator s = new SwitchEventMediatorImpl();
+        assert(!s.ready());
+        s.store(SwitchEventType.PAUSE);
+        assert(s.ready());
+        assert(s.retrieve() == SwitchEventType.PAUSE);
+    }
+
+}

--- a/src/test/java/switch_managers/handlers/PauseResumeEventHandlerTest.java
+++ b/src/test/java/switch_managers/handlers/PauseResumeEventHandlerTest.java
@@ -1,0 +1,31 @@
+package switch_managers.handlers;
+
+import core.StateManager;
+import menus.PauseMenuChoiceStateFactory;
+import menus.PauseMenuManager;
+import menus.options.ChangeOptionsStateFactory;
+import org.junit.jupiter.api.Test;
+import playercreation.PlayerCreatorManager;
+import switch_managers.SwitchEventType;
+
+class PauseResumeEventHandlerTest {
+
+    @Test
+    void handleSwitchEvent() {
+        PauseMenuChoiceStateFactory pauseMenuChoiceStateFactory = new PauseMenuChoiceStateFactory();
+        ChangeOptionsStateFactory changeOptionsStateFactory = new ChangeOptionsStateFactory();
+        PauseMenuManager pauseMenuManager = new PauseMenuManager(pauseMenuChoiceStateFactory, changeOptionsStateFactory);
+
+        PauseResumeEventHandler pauseResumeEventHandler = new PauseResumeEventHandler(pauseMenuManager);
+
+        PlayerCreatorManager creatorManager = new PlayerCreatorManager();
+
+        StateManager pauseSwitch = pauseResumeEventHandler.handleSwitchEvent(SwitchEventType.PAUSE, creatorManager);
+
+        assert (pauseSwitch == pauseMenuManager);
+
+        StateManager resumeSwitch = pauseResumeEventHandler.handleSwitchEvent(SwitchEventType.RESUME, pauseMenuManager);
+
+        assert(resumeSwitch == creatorManager);
+    }
+}


### PR DESCRIPTION
- Add switchEventMediator so states and managers can communicate to the shell that there is a switchEvent
- Provided interface so that all classes can use it without depending on concrete implementation.  
- switch event doesn't persist, so the mediator will delete it once accessed
- 
- Added some docstrings to methods that do not include them
- Added tests for methods that need them - testing common scenarios
- Didn't test simple getters/setters