### PR TITLE
Added switch manager to shell so it registers switchEvents

### DIFF
--- a/src/main/java/game/Game.java
+++ b/src/main/java/game/Game.java
@@ -9,6 +9,8 @@ import menus.PauseMenuChoiceStateFactory;
 import menus.PauseMenuManager;
 import menus.options.ChangeOptionsStateFactory;
 import playercreation.PlayerCreatorManager;
+import switch_managers.SwitchEventMediator;
+import switch_managers.SwitchEventMediatorProxy;
 import switch_managers.handlers.PauseResumeEventHandler;
 
 public class Game {
@@ -23,15 +25,14 @@ public class Game {
         InputHandler inputHandler = new InputHandlerImpl();
         ManagerController managerController = createManagerController();
         StateManager startingManager = getStartingManager();
-        Shell s = new Shell(inputHandler, managerController, startingManager);
+        SwitchEventMediator switchEventMediator = SwitchEventMediatorProxy.getInstance();
+        Shell s = new Shell(inputHandler, managerController, startingManager, switchEventMediator);
         s.startGame();
     }
 
     private StateManager getStartingManager() {
         //should change to a mainMenuManager when one gets created
-        PlayerCreatorManager playerCreatorManager = new PlayerCreatorManager();
-        //playerCreatorManager.initialize();
-        return playerCreatorManager;
+        return new PlayerCreatorManager();
     }
 
     /**

--- a/src/main/java/game/Shell.java
+++ b/src/main/java/game/Shell.java
@@ -1,6 +1,7 @@
 package game;
 
 import core.StateManager;
+import switch_managers.SwitchEventMediator;
 import switch_managers.SwitchEventType;
 import switch_managers.ManagerController;
 import io.InputHandler;
@@ -16,13 +17,17 @@ public class Shell {
 
     private final ManagerController managerController;
     private final InputHandler inputHandler;
+
+    private final SwitchEventMediator switchEventMediator;
     private boolean running;
 
-    public Shell(InputHandler inputHandler, ManagerController managerController, StateManager startingManager) {
+    public Shell(InputHandler inputHandler, ManagerController managerController, StateManager startingManager, SwitchEventMediator switchEventMediator) {
         this.inputHandler = inputHandler;
         this.managerController = managerController;
         this.currentManager = startingManager;
+        this.switchEventMediator = switchEventMediator;
     }
+
 
     /**
      * Starts the game,
@@ -39,6 +44,11 @@ public class Shell {
     private void mainLoop() {
         // The game runs until the User decides to exit the game.
         while (running) {
+
+            if (switchEventMediator.ready()) {
+                switchManager();
+            }
+
             //!!! everything below need to be worked on!
             if (currentManager.awaitInput()) {
                 String input = inputHandler.getChoice(currentManager.getInputValidator());
@@ -46,10 +56,6 @@ public class Shell {
                 currentManager.postInput(input);
             } else {
                 currentManager.preInput();
-            }
-
-            if (currentManager.isDone()) {
-                switchManager();
             }
         }
     }
@@ -62,7 +68,7 @@ public class Shell {
             exitGame();
             return true;
         } else if (doesUserPause(input)) {
-            switchManager();
+            switchEventMediator.store(SwitchEventType.PAUSE);
             return true;
         }
         return false;
@@ -76,24 +82,17 @@ public class Shell {
         //do smth here like saving data to files to be implemented later
     }
 
-    //!!! Shouldn't there be the creation of game method?
-    // private void createStarterGame()
-
-    /**
-     * Returns the manager for the start of the game.
-     */
-    // !!! not sure that I got who the first manager is and how this part works.
-
-
     /**
      * Handles the system to switch between the different managers in the game.
      * (!!!)
      */
     private void switchManager() {
         // !!! get switch event somehow - maybe through a mediator?
-        SwitchEventType switchEventType = SwitchEventType.PAUSE;
+        SwitchEventType switchEventType = switchEventMediator.retrieve();
         this.currentManager = managerController.switchManagers(switchEventType, currentManager);
-        currentManager.initialize();
+        if (currentManager.isDone()) {
+            currentManager.initialize();
+        }
     }
 
     /**


### PR DESCRIPTION
- Added switch events
- Initially, switch event was registered only when currentManager.isDone() was true. This created a problem when a switch event is fired even when the manager is not done. (i.e. starting a battle, the eventManager is not done but still need to switch to the battleManager) 
- switch event therefore now ignores isDone(). 
- currentManager.isDone() logic changed to affect whether initialize() is called or not. 