### PR TITLE
fix factory and enemy object

### DIFF
--- a/src/main/java/objects/battle/enemy/factory/EnemyFactory.java
+++ b/src/main/java/objects/battle/enemy/factory/EnemyFactory.java
@@ -50,24 +50,15 @@ public class EnemyFactory {
      * @param name of the enemy to create
      * @return instance of enemy
      */
-    public EnemyFacade createEnemy(String name){
-        return new EnemyFacade(name, getEnemyInfo(getEnemyData(name)), getEnemyAI(getEnemyData(name),
-                getEnemyInfo(getEnemyData(name))));
-    }
-
-    /**
-     * This method returns the boss instance using the information given by database
-     * @param name of the enemy to create
-     * @return instance of boss
-     */
-    public BossFacade createBoss(String name){
+    public EnemyFighter createEnemy(String name) {
         EnemyData enemyData = getEnemyData(name);
         EnemyInfo enemyInfo = getEnemyInfo(getEnemyData(name));
-        return new BossFacade(name, enemyInfo, getEnemyAI(getEnemyData(name),
-                getEnemyInfo(getEnemyData(name))), translateGimmick(enemyData.gimmick, enemyInfo));
-
-
-
+        if (!(enemyData.gimmick == null)) {
+            return new BossFacade(name, enemyInfo, getEnemyAI(getEnemyData(name),
+                    getEnemyInfo(getEnemyData(name))), translateGimmick(enemyData.gimmick, enemyInfo));
+        }
+        return new EnemyFacade(name, getEnemyInfo(getEnemyData(name)), getEnemyAI(getEnemyData(name),
+                getEnemyInfo(getEnemyData(name))));
     }
 
     /**

--- a/src/main/java/objects/character/BossFacade.java
+++ b/src/main/java/objects/character/BossFacade.java
@@ -26,14 +26,6 @@ public class BossFacade extends EnemyFacade implements EnemyFighter{
     }
 
     /**
-     * This method returns the enemy's gimmick
-     *
-     */
-    public GimmickStrategy getGimmick() {
-        return this.gimmick;
-    }
-
-    /**
      * This method uses the gimmick and displays the string on the console
      *
      */

--- a/src/main/java/objects/character/EnemyFacade.java
+++ b/src/main/java/objects/character/EnemyFacade.java
@@ -177,5 +177,12 @@ public class EnemyFacade extends Character implements EnemyFighter{
     public EnemyPotion getPotion(){
         return this.enemyInfo.getPotion();
     }
+
+    /**
+     * This method uses the gimmick and displays the string on the console
+     *
+     */
+    public void applyGimmick(){
+    }
 }
 

--- a/src/main/java/objects/character/EnemyFighter.java
+++ b/src/main/java/objects/character/EnemyFighter.java
@@ -124,5 +124,9 @@ public interface EnemyFighter {
      */
     EnemyPotion getPotion();
 
+    /**
+     * This method uses the gimmick and displays the string on the console
+     *
+     */
     void applyGimmick();
 }

--- a/src/main/java/objects/character/EnemyFighter.java
+++ b/src/main/java/objects/character/EnemyFighter.java
@@ -123,4 +123,6 @@ public interface EnemyFighter {
      * @return the potion that the enemy has
      */
     EnemyPotion getPotion();
+
+    void applyGimmick();
 }

--- a/src/test/java/battle/enemy/EnemyFactoryTest.java
+++ b/src/test/java/battle/enemy/EnemyFactoryTest.java
@@ -31,7 +31,7 @@ public class EnemyFactoryTest {
         EnemyInfo enemyInfo = new EnemyInfo(skills, 90, 5, SkillType.FIRE, new EnemyPotion(10));
         DefaultAI enemyAI = new DefaultAI(enemyInfo, 50);
         EnemyFactory enemyFactory = new EnemyFactory();
-        EnemyFacade enemy = enemyFactory.createEnemy("goblin");
+        EnemyFighter enemy = enemyFactory.createEnemy("goblin");
         Assertions.assertEquals(enemy.getSkill(0).getDamage(), 20);
         Assertions.assertEquals(enemy.getSkill(0).getType(), SkillType.FIRE);
         Assertions.assertEquals(enemy.getSkill(0).getLag(), 10);
@@ -56,7 +56,7 @@ public class EnemyFactoryTest {
         StatGimmickEntity gimmick = new StatGimmickEntity.StatGimmickBuilder(GimmickType.HEALTH, enemyInfo,
                 30).build();
         EnemyFactory enemyFactory = new EnemyFactory();
-        BossFacade boss = enemyFactory.createBoss("goblin warrior");
+        EnemyFighter boss = enemyFactory.createEnemy("goblin warrior");
         Assertions.assertEquals(boss.getSkill(0).getDamage(), 25);
         Assertions.assertEquals(boss.getSkill(0).getType(), SkillType.EARTH);
         Assertions.assertEquals(boss.getSkill(0).getLag(), 10);
@@ -67,7 +67,6 @@ public class EnemyFactoryTest {
         Assertions.assertEquals(boss.getType(), SkillType.EARTH);
         Assertions.assertEquals(boss.getHealth(), 100);
         Assertions.assertEquals(boss.getName(), "goblin warrior");
-        Assertions.assertTrue(boss.getGimmick() instanceof StatGimmickStrategy);
         Assertions.assertTrue(boss.getEnemyAI() instanceof
                 SmartAI);
     }

--- a/src/test/java/battle/enemy/ai/EnemyActionHandlerTest.java
+++ b/src/test/java/battle/enemy/ai/EnemyActionHandlerTest.java
@@ -4,8 +4,7 @@ import objects.battle.SkillType;
 import objects.battle.enemy.ai.EnemyActionHandler;
 import objects.battle.enemy.ai.EnemyPotionHandler;
 import objects.battle.enemy.factory.EnemyFactory;
-import objects.character.BossFacade;
-import objects.character.EnemyFacade;
+import objects.character.EnemyFighter;
 import objects.character.Player;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -21,7 +20,7 @@ public class EnemyActionHandlerTest {
     public void EnemyPotionHandlerTest1(){
         Player player = new Player("Yasu", SkillType.AIR);
         EnemyFactory enemyFactory = new EnemyFactory();
-        EnemyFacade enemyFacade = enemyFactory.createEnemy("goblin");
+        EnemyFighter enemyFacade = enemyFactory.createEnemy("goblin");
         EnemyPotionHandler potion = new EnemyPotionHandler(enemyFacade.getPotion());
         enemyFacade.changeHealth(-90);
         EnemyActionHandler action = enemyFacade.enemyAction("use skill");
@@ -34,7 +33,7 @@ public class EnemyActionHandlerTest {
     public void EnemyPotionHandlerTest2(){
         Player player = new Player("Yasu", SkillType.EARTH);
         EnemyFactory enemyFactory = new EnemyFactory();
-        BossFacade bossFacade = enemyFactory.createBoss("goblin warrior");
+        EnemyFighter bossFacade = enemyFactory.createEnemy("goblin warrior");
         EnemyPotionHandler potion = new EnemyPotionHandler(bossFacade.getPotion());
         bossFacade.changeHealth(-90);
         EnemyActionHandler action = bossFacade.enemyAction("use skill");

--- a/src/test/java/battle/enemy/gimmick/StatGimmickStrategyTest.java
+++ b/src/test/java/battle/enemy/gimmick/StatGimmickStrategyTest.java
@@ -7,6 +7,7 @@ import objects.battle.enemy.ai.EnemyPotion;
 import objects.battle.enemy.factory.EnemyFactory;
 import objects.battle.enemy.gimmick.*;
 import objects.character.BossFacade;
+import objects.character.EnemyFighter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -85,7 +86,7 @@ public class StatGimmickStrategyTest {
     @Test
     public void UseGimmickTest(){
         EnemyFactory enemyFactory = new EnemyFactory();
-        BossFacade boss = enemyFactory.createBoss("goblin warrior");
+        EnemyFighter boss = enemyFactory.createEnemy("goblin warrior");
         boss.changeHealth(-90);
         boss.applyGimmick();
         Assertions.assertEquals(100, boss.getHealth());


### PR DESCRIPTION
Since the BattleStateManger will only get the name of the enemy from EventDatabase and the manager will not know if the enemy with the name is normal enemy or boss, I implemented useGimmick() in EnemyFighter interface and EnemyFacade class which does not do anything since its a normal enemy. Thus now the factory return EnemyFighter and the BattleStateManager does not have know the type of enemy when they initialize an enemy and EnemyTurnState also does not have to know if its boss or not (it will call enemy.useGimmick() in the beginning of the every enemy's turn, and if the enemy is not boss, it will not do anything. If its a boss, then it actually use it)